### PR TITLE
Validation regex in schemas.py only accepts uppercase SI units

### DIFF
--- a/sandstone/lib/filesystem/atticquota.py
+++ b/sandstone/lib/filesystem/atticquota.py
@@ -118,6 +118,10 @@ class AtticQuota:
         volume_stats.update(usage_stats)
         alerts = self._add_alerts(volume_stats)
 
+        # Validation in schemas.py only accepts uppercase SI units
+        for field in ['used', 'available', 'size']:
+            volume_stats[field] = volume_stats[field].upper()
+
         attic_volume = []
         attic_volume.append(VolumeObject(**volume_stats))
         return (attic_volume, alerts)


### PR DESCRIPTION
```
Sep 16 10:29:33 attic-xfer jupyterhub:   File "/opt/anaconda/envs/sandstone/lib/python2.7/site-packages/sandstone/lib/filesystem/interfaces.py", line 54, in get_filesystem_details
Sep 16 10:29:33 attic-xfer jupyterhub:     (attic_volume, attic_alerts) = attic_quota.get_attic_volume()
Sep 16 10:29:33 attic-xfer jupyterhub:   File "/opt/anaconda/envs/sandstone/lib/python2.7/site-packages/sandstone/lib/filesystem/atticquota.py", line 122, in get_attic_volume
Sep 16 10:29:33 attic-xfer jupyterhub:     attic_volume.append(VolumeObject(**volume_stats))
Sep 16 10:29:33 attic-xfer jupyterhub:   File "/opt/anaconda/envs/sandstone/lib/python2.7/site-packages/sandstone/lib/filesystem/schemas.py", line 34, in __init__
Sep 16 10:29:33 attic-xfer jupyterhub:     raise self.ValidationError('Arguments do not match schema.')
```